### PR TITLE
DAPH-177 update docker base image to use latest tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opguk/nginx:0.1.206
+FROM registry.service.opg.digital/opguk/nginx
 
 RUN  apt-get update && apt-get autoclean && apt-get autoremove && rm -rf /var/lib/{apt,dpkg,cache,log}/ && rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION
deployed sucessfully to:  https://front2-devops01.dev.lpa.opg.digital/home
using: https://jenkins.service.opg.digital/job/LPA/job/lpa_stack_update_deploy/704/
