### PR TITLE
Pin docker image to 0.0.318

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opguk/nginx
+FROM registry.service.opg.digital/opguk/nginx:0.0.318
 
 RUN  apt-get update && apt-get autoclean && apt-get autoremove && rm -rf /var/lib/{apt,dpkg,cache,log}/ && rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Starfox needs to update the base images for the Sirius ECS migration. I've pinned all the refunds version to the latest version in master before our upgrade.