### PR TITLE
remove version pin for nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opguk/nginx:0.0.318
+FROM registry.service.opg.digital/opguk/nginx
 
 RUN  apt-get update && apt-get autoclean && apt-get autoremove && rm -rf /var/lib/{apt,dpkg,cache,log}/ && rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION
The jenkins job for building LPA containers is returning an error while building opg-lpa-maintenance

```
19:19:20 make -C lpa-maintenance newtag=1.0.1017-dev no-cache=
19:19:20 make[1]: Entering directory `/srv/jenkins/build/workspace/LPA/opg_lpa_docker_build/opg-lpa-docker/lpa-maintenance'
19:19:20 cd ../../opg-lpa-maintenance && docker build  -t "registry.service.opg.digital/opguk/lpa-maintenance" .
19:19:20 Sending build context to Docker daemon 557.1 kB
Sending build context to Docker daemon 990.7 kB
Sending build context to Docker daemon 990.7 kB
19:19:20 Step 1/10 : FROM registry.service.opg.digital/opguk/nginx:0.0.318
19:19:20 manifest for registry.service.opg.digital/opguk/nginx:0.0.318 not found
19:19:20 make[1]: *** [build] Error 1
19:19:20 make: *** [lpa-maintenance] Error 2
```

The version requested doesn't exist for nginx (but does for the php-fpm base image in other repos)

Removing this version pin should avoid the errors